### PR TITLE
fix: add authorization checks to /register_group and /toggle_ai

### DIFF
--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -8,6 +8,7 @@ from aiogram import Bot, F, Router
 from aiogram.filters import Command
 from aiogram.types import CallbackQuery, Message
 
+from bot.config import settings
 from bot.db import queries
 from bot.keyboards.inline import admin_ticket_kb
 
@@ -19,6 +20,9 @@ router = Router()
 
 @router.message(Command("register_group"))
 async def cmd_register_group(message: Message, db: aiosqlite.Connection) -> None:
+    if message.from_user.id not in settings.admin_ids:
+        await message.reply("Unauthorized.")
+        return
     chat = message.chat
     if chat.type not in ("supergroup", "group"):
         await message.reply("This command must be used in a forum supergroup.")
@@ -33,6 +37,9 @@ async def cmd_register_group(message: Message, db: aiosqlite.Connection) -> None
 async def cmd_toggle_ai(
     message: Message, db: aiosqlite.Connection, t: Callable[[str], str]
 ) -> None:
+    if message.from_user.id not in settings.admin_ids:
+        await message.reply("Unauthorized.")
+        return
     parts = message.text.split()
     if len(parts) < 2:
         await message.reply("Usage: /toggle_ai <user_id>")


### PR DESCRIPTION
## Summary
- Guard `/register_group` (admin.py:20) with `admin_ids` check — anyone could previously hijack user routing
- Guard `/toggle_ai` (admin.py:32) with `admin_ids` check — anyone could previously disable AI for any conversation
- Wire `settings.admin_ids` into both handlers (already defined in `config.py`, now enforced)

## Test plan
- [ ] Set `ADMIN_IDS=[<your_telegram_id>]` in `.env`
- [ ] Send `/register_group` from a non-admin — expect `Unauthorized.`
- [ ] Send `/toggle_ai 123` from a non-admin — expect `Unauthorized.`
- [ ] Send both commands from a configured admin — expect normal behavior

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)