### PR TITLE
fix: admin handler — cross-group reply, close ownership, non-text replies, supergroup filter, channel posts

### DIFF
--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -18,6 +18,26 @@ async def get_active_group(db: aiosqlite.Connection) -> Optional[dict]:
     return {"id": row[0], "telegram_group_id": row[1], "topic_count": row[2]}
 
 
+async def get_group_by_telegram_id(
+    db: aiosqlite.Connection, telegram_group_id: int
+) -> Optional[dict]:
+    """Return a registered admin group by its Telegram chat ID, or None."""
+    async with db.execute(
+        "SELECT id, telegram_group_id, topic_count, is_active FROM admin_groups "
+        "WHERE telegram_group_id = ?",
+        (telegram_group_id,),
+    ) as cur:
+        row = await cur.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "telegram_group_id": row[1],
+        "topic_count": row[2],
+        "is_active": bool(row[3]),
+    }
+
+
 async def register_group(db: aiosqlite.Connection, telegram_group_id: int) -> int:
     cur = await db.execute(
         "INSERT OR IGNORE INTO admin_groups (telegram_group_id) VALUES (?)",
@@ -63,6 +83,24 @@ async def get_user(db: aiosqlite.Connection, telegram_id: int) -> Optional[dict]
     async with db.execute(
         "SELECT id, telegram_id, language, group_id, topic_id FROM users WHERE telegram_id = ?",
         (telegram_id,),
+    ) as cur:
+        row = await cur.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "telegram_id": row[1],
+        "language": row[2],
+        "group_id": row[3],
+        "topic_id": row[4],
+    }
+
+
+async def get_user_by_id(db: aiosqlite.Connection, user_id: int) -> Optional[dict]:
+    """Return a user row by internal primary key."""
+    async with db.execute(
+        "SELECT id, telegram_id, language, group_id, topic_id FROM users WHERE id = ?",
+        (user_id,),
     ) as cur:
         row = await cur.fetchone()
     if row is None:

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -68,6 +68,26 @@ async def handle_close(
     t: Callable[[str], str],
 ) -> None:
     conv_id = int(callback.data.split(":")[1])
+    conv = await queries.get_conversation_by_id(db, conv_id)
+    if conv is None:
+        await callback.answer("Conversation not found.", show_alert=True)
+        return
+
+    # Issue #11: verify the conversation's user belongs to the group where
+    # this callback originated — prevents cross-group close operations.
+    origin_group = await queries.get_group_by_telegram_id(db, callback.message.chat.id)
+    if origin_group is None:
+        await callback.answer("Unrecognised group.", show_alert=True)
+        return
+
+    user = await queries.get_user_by_id(db, conv["user_id"])
+    if user is None or user["group_id"] != origin_group["id"]:
+        await callback.answer(
+            "Permission denied: conversation belongs to a different group.",
+            show_alert=True,
+        )
+        return
+
     closed_by = callback.from_user.id
     await queries.set_conversation_status(db, conv_id, "closed", closed_by=closed_by)
     await callback.answer(t("ticket_closed_admin"))
@@ -112,15 +132,26 @@ async def handle_admin_reply(
     db: aiosqlite.Connection,
 ) -> None:
     """Forward agent replies from admin topic to the corresponding user."""
-    if message.from_user and message.from_user.is_bot:
+    # Issue #22: guard against channel posts and anonymous senders
+    if not message.from_user:
         return
 
+    if message.from_user.is_bot:
+        return
+
+    # Issue #14: only process messages from registered admin groups
+    admin_group = await queries.get_group_by_telegram_id(db, message.chat.id)
+    if admin_group is None:
+        return
+
+    # Issue #3: filter by both group_id and topic_id to prevent cross-group
+    # misdelivery when the same topic_id appears in multiple forum groups.
     async with db.execute(
         "SELECT u.telegram_id, c.id AS conv_id FROM users u "
         "JOIN conversations c ON c.user_id = u.id "
-        "WHERE u.topic_id = ? AND c.status != 'closed' "
+        "WHERE u.group_id = ? AND u.topic_id = ? AND c.status != 'closed' "
         "ORDER BY c.id DESC LIMIT 1",
-        (message.message_thread_id,),
+        (admin_group["id"], message.message_thread_id),
     ) as cur:
         row = await cur.fetchone()
 
@@ -128,8 +159,25 @@ async def handle_admin_reply(
         return
 
     user_telegram_id, conv_id = row[0], row[1]
+
+    # Issue #12: handle non-text messages (photos, voice, stickers, etc.)
     text = message.text or message.caption or ""
     if not text:
+        logger.warning(
+            "Agent sent non-text message (type=%s) in conv %s; forwarding media to user %s",
+            message.content_type,
+            conv_id,
+            user_telegram_id,
+        )
+        try:
+            await message.copy_to(chat_id=user_telegram_id)
+        except Exception:
+            logger.exception(
+                "Failed to forward media message to user %s", user_telegram_id
+            )
+        await queries.save_message(db, conv_id, "agent", f"[{message.content_type}]")
+        await queries.set_ai_enabled(db, conv_id, False)
+        await queries.set_conversation_status(db, conv_id, "human")
         return
 
     await queries.save_message(db, conv_id, "agent", text)


### PR DESCRIPTION
## Summary

Fixes 5 issues found during code review of the admin handler:

- **#3 / cross-group misdelivery**: `handle_admin_reply` now filters the user lookup by both `group_id` (internal FK) and `topic_id`, preventing wrong delivery when topic IDs collide across multiple admin forum groups.
- **#11 / close ownership**: `handle_close` verifies that the conversation's user belongs to the admin group where the callback originated before closing the ticket.
- **#12 / non-text replies silently dropped**: When an agent sends a photo, voice message, sticker, etc. (no text/caption), the message is now forwarded to the user via `copy_to()` and logged as `[content_type]` in the message history. A warning is emitted to the logger.
- **#14 / supergroup filter**: `handle_admin_reply` now looks up `message.chat.id` in the `admin_groups` table and returns early for any unregistered supergroup.
- **#22 / `from_user` is None guard**: Added `if not message.from_user: return` at the top of `handle_admin_reply` to safely handle channel posts and anonymous sender edge cases.

Also adds `get_group_by_telegram_id()` and `get_user_by_id()` query helpers used by the new ownership and registration checks.

## Test plan

- [ ] Reply in a topic of a registered group → message delivered to correct user
- [ ] Reply in the same topic ID in a second registered group → each user gets only their own message
- [ ] Close ticket callback from a different group → rejected with "Permission denied"
- [ ] Agent sends a photo with no caption → photo forwarded to user, warning logged, AI disabled
- [ ] Bot message in admin topic → ignored (is_bot check)
- [ ] Channel post (from_user is None) → ignored silently
- [ ] Message in an unregistered supergroup → ignored silently

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)