### PR TITLE
fix: i18n middleware — db.fetchone() + missing commit + no-op UPDATE

### DIFF
--- a/bot/middlewares/i18n.py
+++ b/bot/middlewares/i18n.py
@@ -98,18 +98,30 @@ class I18nMiddleware(BaseMiddleware):
     @staticmethod
     async def _get_stored_lang(db: Any, telegram_id: int) -> str | None:
         """Return stored language for ``telegram_id``, or None if not found."""
-        row = await db.fetchone(
+        # Fix #1: aiosqlite has no db.fetchone(); use cursor.fetchone() instead.
+        async with db.execute(
             "SELECT language FROM users WHERE telegram_id = ?",
             (telegram_id,),
-        )
-        if row and row["language"] in SUPPORTED_LANGS:
-            return row["language"]
+        ) as cur:
+            row = await cur.fetchone()
+        if row and row[0] in SUPPORTED_LANGS:
+            return row[0]
         return None
 
     @staticmethod
     async def _store_lang(db: Any, telegram_id: int, lang: str) -> None:
-        """Persist detected language (only update the language column)."""
+        """Persist detected language for returning users only."""
+        # Fix #3: only UPDATE when the row already exists; INSERT OR IGNORE would
+        # silently create an incomplete row — create_user() owns new-user inserts.
+        async with db.execute(
+            "SELECT 1 FROM users WHERE telegram_id = ?", (telegram_id,)
+        ) as cur:
+            exists = await cur.fetchone()
+        if not exists:
+            return
         await db.execute(
             "UPDATE users SET language = ? WHERE telegram_id = ?",
             (lang, telegram_id),
         )
+        # Fix #2: commit so the language write is not silently rolled back.
+        await db.commit()


### PR DESCRIPTION
## Summary
- **Fix #1** (`i18n.py:101`): replace the non-existent `db.fetchone()` call with the correct aiosqlite pattern — `async with db.execute(...) as cur: row = await cur.fetchone()`. Also switches from dict-style access (`row["language"]`) to index access (`row[0]`) since aiosqlite rows are tuples. Without this fix all users always got the fallback language.
- **Fix #2** (`i18n.py:112`): add `await db.commit()` after the `UPDATE` in `_store_lang` so language writes are not silently rolled back on every message.
- **Fix #3** (`i18n.py:110`): guard `_store_lang` with a `SELECT 1` existence check so the `UPDATE` is skipped for new users (it was a no-op that added an unnecessary DB round-trip). `create_user()` owns first-contact inserts.

## Test plan
- [ ] New user message: `_get_stored_lang` returns `None`, `_store_lang` exits early (no row yet), detected language is used
- [ ] Return user message: `_get_stored_lang` returns stored language via `cur.fetchone()`, correct translator injected
- [ ] Language change via `update_user_language`: next message picks up the new value
- [ ] User with unsupported/unknown `language_code`: falls back to `en`
- [ ] `t("welcome")` returns the right string in each of en/ru/ua

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)