### PR TITLE
fix: AI singleton, DB indices, agent role mapping, /stats, register_group UX, i18n keyboard, log level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ AI_BASE_URL=
 AI_SYSTEM_PROMPT=You are a helpful support assistant.
 DB_PATH=./data/bot.db
 ADMIN_IDS=[123456789]
+LOG_LEVEL=INFO

--- a/bot/ai/client.py
+++ b/bot/ai/client.py
@@ -1,16 +1,21 @@
 from bot.config import settings
 
+# Module-level singletons — initialized once at import time
+if settings.ai_provider == "claude":
+    from anthropic import AsyncAnthropic as _AsyncAnthropic
+    _claude_client = _AsyncAnthropic(api_key=settings.ai_api_key)
+    _openai_client = None
+else:
+    from openai import AsyncOpenAI as _AsyncOpenAI
+    _claude_client = None
+    _openai_client = _AsyncOpenAI(
+        api_key=settings.ai_api_key,
+        base_url=settings.ai_base_url or None,
+    )
+
 
 async def send_message(history: list[dict], system_prompt: str) -> str:
-    """Send message to AI provider and return reply text.
-
-    Args:
-        history: List of {"role": "user"/"assistant", "content": "..."} dicts.
-        system_prompt: System prompt for the AI.
-
-    Returns:
-        AI reply text.
-    """
+    """Send message to AI provider and return reply text."""
     if settings.ai_provider == "claude":
         return await _send_claude(history, system_prompt)
     else:
@@ -18,10 +23,7 @@ async def send_message(history: list[dict], system_prompt: str) -> str:
 
 
 async def _send_claude(history: list[dict], system_prompt: str) -> str:
-    import anthropic
-
-    client = anthropic.AsyncAnthropic(api_key=settings.ai_api_key)
-    response = await client.messages.create(
+    response = await _claude_client.messages.create(
         model=settings.ai_model,
         max_tokens=1024,
         system=system_prompt,
@@ -31,15 +33,8 @@ async def _send_claude(history: list[dict], system_prompt: str) -> str:
 
 
 async def _send_openai(history: list[dict], system_prompt: str) -> str:
-    from openai import AsyncOpenAI
-
-    kwargs = {"api_key": settings.ai_api_key}
-    if settings.ai_base_url:
-        kwargs["base_url"] = settings.ai_base_url
-
-    client = AsyncOpenAI(**kwargs)
     messages = [{"role": "system", "content": system_prompt}] + history
-    response = await client.chat.completions.create(
+    response = await _openai_client.chat.completions.create(
         model=settings.ai_model,
         messages=messages,
     )

--- a/bot/config.py
+++ b/bot/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     ai_system_prompt: str = "You are a helpful support assistant."
     db_path: str = "./data/bot.db"
     admin_ids: List[int] = []
+    log_level: str = "INFO"
 
 
 settings = Settings()

--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -40,9 +40,16 @@ CREATE TABLE IF NOT EXISTS messages (
     conversation_id INTEGER NOT NULL REFERENCES conversations(id),
     role TEXT NOT NULL,
     text TEXT NOT NULL,
-    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    timestamp DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    sender_id INTEGER
 )
 """
+
+_INDICES = [
+    "CREATE INDEX IF NOT EXISTS idx_users_topic_id ON users(topic_id)",
+    "CREATE INDEX IF NOT EXISTS idx_conversations_user_id ON conversations(user_id)",
+    "CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id)",
+]
 
 
 async def init_db(db_path: str) -> None:
@@ -51,4 +58,11 @@ async def init_db(db_path: str) -> None:
         await db.execute(CREATE_USERS)
         await db.execute(CREATE_CONVERSATIONS)
         await db.execute(CREATE_MESSAGES)
+        for idx_sql in _INDICES:
+            await db.execute(idx_sql)
+        # Migration: add sender_id to existing databases
+        try:
+            await db.execute("ALTER TABLE messages ADD COLUMN sender_id INTEGER")
+        except Exception:
+            pass  # Column already exists
         await db.commit()

--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -38,13 +38,21 @@ async def get_group_by_telegram_id(
     }
 
 
-async def register_group(db: aiosqlite.Connection, telegram_group_id: int) -> int:
+async def register_group(db: aiosqlite.Connection, telegram_group_id: int) -> tuple[int, bool]:
+    """Register a group. Returns (group_id, is_new). is_new=False when already registered."""
     cur = await db.execute(
         "INSERT OR IGNORE INTO admin_groups (telegram_group_id) VALUES (?)",
         (telegram_group_id,),
     )
     await db.commit()
-    return cur.lastrowid
+    if cur.lastrowid:
+        return cur.lastrowid, True
+    # Duplicate: fetch existing id
+    async with db.execute(
+        "SELECT id FROM admin_groups WHERE telegram_group_id = ?", (telegram_group_id,)
+    ) as cur2:
+        row = await cur2.fetchone()
+        return row[0], False
 
 
 async def increment_topic_count(db: aiosqlite.Connection, group_id: int) -> int:
@@ -205,13 +213,67 @@ async def get_conversation_by_id(
 # ── Messages ──────────────────────────────────────────────────────────────────
 
 async def save_message(
-    db: aiosqlite.Connection, conversation_id: int, role: str, text: str
+    db: aiosqlite.Connection,
+    conversation_id: int,
+    role: str,
+    text: str,
+    sender_id: Optional[int] = None,
 ) -> None:
     await db.execute(
-        "INSERT INTO messages (conversation_id, role, text) VALUES (?, ?, ?)",
-        (conversation_id, role, text),
+        "INSERT INTO messages (conversation_id, role, text, sender_id) VALUES (?, ?, ?, ?)",
+        (conversation_id, role, text, sender_id),
     )
     await db.commit()
+
+
+# ── Stats ──────────────────────────────────────────────────────────────────────
+
+async def get_stats(db: aiosqlite.Connection) -> dict:
+    async with db.execute(
+        "SELECT COUNT(*) FROM conversations WHERE status != 'closed'"
+    ) as cur:
+        open_count = (await cur.fetchone())[0]
+
+    async with db.execute(
+        "SELECT COUNT(*) FROM conversations WHERE status = 'closed'"
+    ) as cur:
+        closed_count = (await cur.fetchone())[0]
+
+    # Average seconds from conversation creation to first agent reply
+    async with db.execute(
+        """
+        SELECT AVG((julianday(m.timestamp) - julianday(c.created_at)) * 86400.0)
+        FROM conversations c
+        JOIN messages m ON m.conversation_id = c.id
+        WHERE m.role = 'agent'
+          AND m.id = (
+              SELECT MIN(id) FROM messages
+              WHERE conversation_id = c.id AND role = 'agent'
+          )
+        """
+    ) as cur:
+        row = await cur.fetchone()
+        avg_response_time = row[0] if row and row[0] is not None else None
+
+    # Active agents: distinct sender_ids with role='agent' that replied in last 24h
+    async with db.execute(
+        """
+        SELECT COUNT(DISTINCT sender_id)
+        FROM messages
+        WHERE role = 'agent'
+          AND sender_id IS NOT NULL
+          AND timestamp >= datetime('now', '-24 hours')
+        """
+    ) as cur:
+        row = await cur.fetchone()
+        active_agents = row[0] if row else 0
+
+    return {
+        "open_count": open_count,
+        "closed_count": closed_count,
+        "avg_response_time": avg_response_time,
+        "active_agents": active_agents,
+    }
 
 
 async def get_conversation_history(
@@ -226,6 +288,10 @@ async def get_conversation_history(
     result = []
     for role, text in rows:
         # Map DB roles to AI roles
-        ai_role = "assistant" if role in ("ai", "agent") else "user"
-        result.append({"role": ai_role, "content": text})
+        if role == "ai":
+            result.append({"role": "assistant", "content": text})
+        elif role == "agent":
+            result.append({"role": "user", "content": f"[Support Agent]: {text}"})
+        else:
+            result.append({"role": "user", "content": text})
     return result

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -27,8 +27,36 @@ async def cmd_register_group(message: Message, db: aiosqlite.Connection) -> None
     if chat.type not in ("supergroup", "group"):
         await message.reply("This command must be used in a forum supergroup.")
         return
-    await queries.register_group(db, chat.id)
-    await message.reply(f"Group {chat.id} registered as a support group.")
+    group_id, is_new = await queries.register_group(db, chat.id)
+    if not is_new:
+        await message.reply(f"This group is already registered (ID: {group_id}).")
+        return
+    await message.reply(f"✅ Group {chat.id} registered as a support group (ID: {group_id}).")
+
+
+# ── /stats ────────────────────────────────────────────────────────────────────
+
+@router.message(Command("stats"))
+async def cmd_stats(message: Message, db: aiosqlite.Connection) -> None:
+    stats = await queries.get_stats(db)
+    avg_rt = stats["avg_response_time"]
+    if avg_rt is None:
+        avg_str = "N/A"
+    elif avg_rt < 60:
+        avg_str = f"{avg_rt:.0f}s"
+    elif avg_rt < 3600:
+        avg_str = f"{avg_rt / 60:.1f}m"
+    else:
+        avg_str = f"{avg_rt / 3600:.1f}h"
+
+    await message.reply(
+        "📊 <b>Support Stats</b>\n\n"
+        f"Open tickets: {stats['open_count']}\n"
+        f"Closed tickets: {stats['closed_count']}\n"
+        f"Avg first response: {avg_str}\n"
+        f"Active agents (24h): {stats['active_agents']}",
+        parse_mode="HTML",
+    )
 
 
 # ── /toggle_ai ────────────────────────────────────────────────────────────────
@@ -187,7 +215,7 @@ async def handle_admin_reply(
         await queries.set_conversation_status(db, conv_id, "human")
         return
 
-    await queries.save_message(db, conv_id, "agent", text)
+    await queries.save_message(db, conv_id, "agent", text, sender_id=message.from_user.id)
     await queries.set_ai_enabled(db, conv_id, False)
     await queries.set_conversation_status(db, conv_id, "human")
 

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -1,9 +1,12 @@
+from typing import Callable, Optional
+
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 
-def talk_to_human_kb() -> InlineKeyboardMarkup:
+def talk_to_human_kb(t: Optional[Callable[[str], str]] = None) -> InlineKeyboardMarkup:
+    label = t("talk_to_human") if t is not None else "Talk to human 🙋"
     return InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text="Talk to human 🙋", callback_data="escalate")]
+        [InlineKeyboardButton(text=label, callback_data="escalate")]
     ])
 
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from bot.db.models import init_db
 from bot.handlers import admin, user
 from bot.middlewares.i18n import I18nMiddleware
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
 
 
 class _DbMiddleware:


### PR DESCRIPTION
Closes #4

## Summary

- **#9** `ai/client.py`: Move `AsyncAnthropic`/`AsyncOpenAI` to module-level singletons — one HTTP client for the lifetime of the process.
- **#15** `keyboards/inline.py`: `talk_to_human_kb()` now accepts an optional `t` translator callable and uses `t("talk_to_human")` for the button label.
- **#16** `db/queries.py`: `get_conversation_history()` maps `role == "agent"` to `{"role": "user", "content": "[Support Agent]: ..."}` so the AI never treats agent replies as its own output.
- **#17** `handlers/admin.py` + `db/queries.py`: Implement `/stats` command showing open/closed ticket counts, avg first-response time, and active agents in last 24h. Add `sender_id` column to `messages` (with auto-migration) and pass agent's `from_user.id` when saving agent messages.
- **#18** `db/models.py`: Add three indices — `idx_users_topic_id`, `idx_conversations_user_id`, `idx_messages_conversation_id`.
- **#19** `db/queries.py`: `register_group()` returns `(group_id, is_new: bool)` instead of relying on `INSERT OR IGNORE` silently returning 0. Handler replies "already registered" when `is_new=False`.
- **#21** `config.py` + `main.py`: Add `log_level` setting (default `INFO`) read from env; `logging.basicConfig` uses it. Add `LOG_LEVEL=INFO` to `.env.example`.

## Test plan

- [ ] Start bot fresh — DB initialises with all indices and `sender_id` column.
- [ ] Start bot against existing DB — migration silently adds `sender_id` without error.
- [ ] `/register_group` in unregistered forum → success reply with group ID.
- [ ] `/register_group` again → "already registered" reply (no crash).
- [ ] Agent replies in topic → message saved with `sender_id`; AI history shows `[Support Agent]:` prefix instead of treating reply as AI's own output.
- [ ] `/stats` shows open/closed counts, avg response time, and active agents (24h).
- [ ] AI reply button label matches user's locale (uses `talk_to_human` key).
- [ ] Set `LOG_LEVEL=DEBUG` in env → debug-level logs appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)