### PR TITLE
feat: AI gating — disable AI when no API key

### DIFF
--- a/bot/ai/client.py
+++ b/bot/ai/client.py
@@ -14,8 +14,10 @@ else:
     )
 
 
-async def send_message(history: list[dict], system_prompt: str) -> str:
-    """Send message to AI provider and return reply text."""
+async def send_message(history: list[dict], system_prompt: str) -> str | None:
+    """Send message to AI provider and return reply text, or None if AI is unavailable."""
+    if not settings.ai_available:
+        return None
     if settings.ai_provider == "claude":
         return await _send_claude(history, system_prompt)
     else:

--- a/bot/config.py
+++ b/bot/config.py
@@ -15,5 +15,9 @@ class Settings(BaseSettings):
     admin_ids: List[int] = []
     log_level: str = "INFO"
 
+    @property
+    def ai_available(self) -> bool:
+        return bool(self.ai_api_key)
+
 
 settings = Settings()

--- a/bot/handlers/user.py
+++ b/bot/handlers/user.py
@@ -155,7 +155,7 @@ async def _process_user_message(
         except Exception:
             logger.exception("Failed to forward message to admin topic for user %s", tg_user.id)
 
-    if not conv["ai_enabled"]:
+    if not settings.ai_available or not conv["ai_enabled"]:
         return
 
     history = await queries.get_conversation_history(db, conv["id"])
@@ -164,6 +164,9 @@ async def _process_user_message(
     except Exception:
         logger.exception("AI call failed for conversation %s", conv["id"])
         await message.answer(t("ai_unavailable"), reply_markup=talk_to_human_kb())
+        return
+
+    if ai_text is None:
         return
 
     await queries.save_message(db, conv["id"], "ai", ai_text)


### PR DESCRIPTION
## Summary
- Add `ai_available` computed property to `Settings` that returns `True` only when `AI_API_KEY` is non-empty
- Guard `send_message()` in `bot/ai/client.py` — returns `None` when AI is unavailable
- Add `settings.ai_available` check in `_process_user_message` before attempting any AI call
- Handle `None` return from `send_message` gracefully (silent no-op)

Closes #13

## Test plan
- [ ] Run bot without `AI_API_KEY` set — verify no AI replies are sent, no errors logged
- [ ] Run bot with `AI_API_KEY` set — verify AI replies work as before
- [ ] Toggle AI off for a conversation — verify AI stops replying even with key set
- [ ] Remove `AI_API_KEY` at runtime — verify existing conversations stop getting AI replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)