### PR TITLE
feat: FAQ system — DB, queries, and admin panel via bot DM

### DIFF
--- a/bot/db/models.py
+++ b/bot/db/models.py
@@ -47,6 +47,17 @@ CREATE TABLE IF NOT EXISTS messages (
 )
 """
 
+CREATE_FAQ_ITEMS = """
+CREATE TABLE IF NOT EXISTS faq_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    question TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    media_file_id TEXT,
+    position INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+)
+"""
+
 _INDICES = [
     "CREATE INDEX IF NOT EXISTS idx_users_topic_id ON users(topic_id)",
     "CREATE INDEX IF NOT EXISTS idx_conversations_user_id ON conversations(user_id)",
@@ -60,6 +71,7 @@ async def init_db(db_path: str) -> None:
         await db.execute(CREATE_USERS)
         await db.execute(CREATE_CONVERSATIONS)
         await db.execute(CREATE_MESSAGES)
+        await db.execute(CREATE_FAQ_ITEMS)
         for idx_sql in _INDICES:
             await db.execute(idx_sql)
         # Migration: add sender_id to existing databases

--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -285,6 +285,98 @@ async def get_stats(db: aiosqlite.Connection) -> dict:
     }
 
 
+# ── FAQ ───────────────────────────────────────────────────────────────────────
+
+async def get_all_faq(db: aiosqlite.Connection) -> list[dict]:
+    async with db.execute(
+        "SELECT id, question, answer, media_file_id, position FROM faq_items ORDER BY position ASC"
+    ) as cur:
+        rows = await cur.fetchall()
+    return [dict(r) for r in rows]
+
+
+async def get_faq_by_id(db: aiosqlite.Connection, faq_id: int) -> Optional[dict]:
+    async with db.execute(
+        "SELECT id, question, answer, media_file_id, position FROM faq_items WHERE id = ?",
+        (faq_id,),
+    ) as cur:
+        row = await cur.fetchone()
+    return dict(row) if row else None
+
+
+async def create_faq(
+    db: aiosqlite.Connection,
+    question: str,
+    answer: str,
+    media_file_id: Optional[str] = None,
+) -> int:
+    async with db.execute("SELECT COALESCE(MAX(position), -1) + 1 FROM faq_items") as cur:
+        next_pos = (await cur.fetchone())[0]
+    cur = await db.execute(
+        "INSERT INTO faq_items (question, answer, media_file_id, position) VALUES (?, ?, ?, ?)",
+        (question, answer, media_file_id, next_pos),
+    )
+    await db.commit()
+    return cur.lastrowid
+
+
+async def update_faq(
+    db: aiosqlite.Connection,
+    faq_id: int,
+    question: Optional[str] = None,
+    answer: Optional[str] = None,
+    media_file_id: Optional[str] = None,
+) -> None:
+    updates, params = [], []
+    if question is not None:
+        updates.append("question = ?")
+        params.append(question)
+    if answer is not None:
+        updates.append("answer = ?")
+        params.append(answer)
+    if media_file_id is not None:
+        updates.append("media_file_id = ?")
+        params.append(media_file_id)
+    if not updates:
+        return
+    params.append(faq_id)
+    await db.execute(
+        f"UPDATE faq_items SET {', '.join(updates)} WHERE id = ?", params
+    )
+    await db.commit()
+
+
+async def delete_faq(db: aiosqlite.Connection, faq_id: int) -> None:
+    await db.execute("DELETE FROM faq_items WHERE id = ?", (faq_id,))
+    await db.commit()
+
+
+async def reorder_faq(db: aiosqlite.Connection, faq_id: int, new_position: int) -> None:
+    async with db.execute("SELECT position FROM faq_items WHERE id = ?", (faq_id,)) as cur:
+        row = await cur.fetchone()
+    if row is None:
+        return
+    old_position = row[0]
+    if new_position == old_position:
+        return
+    if new_position < old_position:
+        await db.execute(
+            "UPDATE faq_items SET position = position + 1 "
+            "WHERE position >= ? AND position < ?",
+            (new_position, old_position),
+        )
+    else:
+        await db.execute(
+            "UPDATE faq_items SET position = position - 1 "
+            "WHERE position > ? AND position <= ?",
+            (old_position, new_position),
+        )
+    await db.execute(
+        "UPDATE faq_items SET position = ? WHERE id = ?", (new_position, faq_id)
+    )
+    await db.commit()
+
+
 async def get_conversation_history(
     db: aiosqlite.Connection, conversation_id: int
 ) -> list[dict]:

--- a/bot/handlers/faq_admin.py
+++ b/bot/handlers/faq_admin.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import aiosqlite
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import CallbackQuery, Message
+
+from bot.config import settings
+from bot.db import queries
+from bot.handlers.admin import IsAdmin
+from bot.keyboards.inline import faq_admin_list_kb, faq_confirm_delete_kb
+
+router = Router()
+_is_admin = IsAdmin()
+
+
+class AddFAQ(StatesGroup):
+    waiting_question = State()
+    waiting_answer = State()
+
+
+class EditFAQ(StatesGroup):
+    waiting_question = State()
+    waiting_answer = State()
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+async def _send_faq_list(message: Message, db: aiosqlite.Connection) -> None:
+    items = await queries.get_all_faq(db)
+    if not items:
+        await message.answer("No FAQ items yet.", reply_markup=faq_admin_list_kb([]))
+        return
+    text_parts = ["<b>FAQ items:</b>\n"]
+    for i, item in enumerate(items, 1):
+        text_parts.append(f"{i}. <b>{item['question']}</b>")
+    await message.answer("\n".join(text_parts), reply_markup=faq_admin_list_kb(items))
+
+
+# ── /faq command ─────────────────────────────────────────────────────────────
+
+@router.message(Command("faq"), _is_admin, F.chat.type == "private")
+async def cmd_faq(message: Message, db: aiosqlite.Connection, state: FSMContext) -> None:
+    await state.clear()
+    await _send_faq_list(message, db)
+
+
+# ── Add flow ─────────────────────────────────────────────────────────────────
+
+@router.callback_query(F.data == "faq_add", _is_admin)
+async def faq_add_start(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.answer()
+    await callback.message.answer("Send the FAQ question (this will be the button label):")
+    await state.set_state(AddFAQ.waiting_question)
+
+
+@router.message(AddFAQ.waiting_question, F.text)
+async def faq_add_question(message: Message, state: FSMContext) -> None:
+    await state.update_data(question=message.text)
+    await message.answer("Now send the answer (supports text, photos with caption, HTML formatting):")
+    await state.set_state(AddFAQ.waiting_answer)
+
+
+@router.message(AddFAQ.waiting_answer, F.photo)
+async def faq_add_answer_photo(message: Message, state: FSMContext, db: aiosqlite.Connection) -> None:
+    data = await state.get_data()
+    answer_text = message.caption or ""
+    media_file_id = message.photo[-1].file_id
+    await queries.create_faq(db, data["question"], answer_text, media_file_id=media_file_id)
+    await state.clear()
+    await message.answer("FAQ item added!")
+    await _send_faq_list(message, db)
+
+
+@router.message(AddFAQ.waiting_answer, F.text)
+async def faq_add_answer_text(message: Message, state: FSMContext, db: aiosqlite.Connection) -> None:
+    data = await state.get_data()
+    await queries.create_faq(db, data["question"], message.text)
+    await state.clear()
+    await message.answer("FAQ item added!")
+    await _send_faq_list(message, db)
+
+
+# ── Edit flow ────────────────────────────────────────────────────────────────
+
+@router.callback_query(F.data.startswith("faq_edit:"), _is_admin)
+async def faq_edit_start(callback: CallbackQuery, state: FSMContext, db: aiosqlite.Connection) -> None:
+    faq_id = int(callback.data.split(":")[1])
+    item = await queries.get_faq_by_id(db, faq_id)
+    if item is None:
+        await callback.answer("FAQ item not found.", show_alert=True)
+        return
+    await callback.answer()
+    preview = f"<b>Question:</b> {item['question']}\n<b>Answer:</b> {item['answer']}"
+    if item["media_file_id"]:
+        preview += "\n(has attached photo)"
+    await callback.message.answer(preview)
+    await callback.message.answer('Send new question text (or /skip to keep current):')
+    await state.set_state(EditFAQ.waiting_question)
+    await state.update_data(faq_id=faq_id)
+
+
+@router.message(EditFAQ.waiting_question, F.text)
+async def faq_edit_question(message: Message, state: FSMContext) -> None:
+    if message.text != "/skip":
+        await state.update_data(new_question=message.text)
+    await message.answer("Send new answer (or /skip to keep current):")
+    await state.set_state(EditFAQ.waiting_answer)
+
+
+@router.message(EditFAQ.waiting_answer, F.photo)
+async def faq_edit_answer_photo(message: Message, state: FSMContext, db: aiosqlite.Connection) -> None:
+    data = await state.get_data()
+    faq_id = data["faq_id"]
+    await queries.update_faq(
+        db,
+        faq_id,
+        question=data.get("new_question"),
+        answer=message.caption or "",
+        media_file_id=message.photo[-1].file_id,
+    )
+    await state.clear()
+    await message.answer("FAQ item updated!")
+    await _send_faq_list(message, db)
+
+
+@router.message(EditFAQ.waiting_answer, F.text)
+async def faq_edit_answer_text(message: Message, state: FSMContext, db: aiosqlite.Connection) -> None:
+    data = await state.get_data()
+    faq_id = data["faq_id"]
+    kwargs: dict = {}
+    if "new_question" in data:
+        kwargs["question"] = data["new_question"]
+    if message.text != "/skip":
+        kwargs["answer"] = message.text
+    if kwargs:
+        await queries.update_faq(db, faq_id, **kwargs)
+    await state.clear()
+    await message.answer("FAQ item updated!")
+    await _send_faq_list(message, db)
+
+
+# ── Delete flow ──────────────────────────────────────────────────────────────
+
+@router.callback_query(F.data.startswith("faq_del:"), _is_admin)
+async def faq_delete_confirm(callback: CallbackQuery, db: aiosqlite.Connection) -> None:
+    faq_id = int(callback.data.split(":")[1])
+    item = await queries.get_faq_by_id(db, faq_id)
+    if item is None:
+        await callback.answer("FAQ item not found.", show_alert=True)
+        return
+    await callback.answer()
+    await callback.message.answer(
+        f"Delete <b>{item['question']}</b>? Are you sure?",
+        reply_markup=faq_confirm_delete_kb(faq_id),
+    )
+
+
+@router.callback_query(F.data.startswith("faq_del_yes:"), _is_admin)
+async def faq_delete_yes(callback: CallbackQuery, db: aiosqlite.Connection) -> None:
+    faq_id = int(callback.data.split(":")[1])
+    await queries.delete_faq(db, faq_id)
+    await callback.answer("Deleted.")
+    try:
+        await callback.message.edit_reply_markup(reply_markup=None)
+    except Exception:
+        pass
+    await _send_faq_list(callback.message, db)
+
+
+@router.callback_query(F.data == "faq_del_no")
+async def faq_delete_no(callback: CallbackQuery) -> None:
+    await callback.answer("Cancelled.")
+    try:
+        await callback.message.edit_reply_markup(reply_markup=None)
+    except Exception:
+        pass
+
+
+# ── No-op for question label buttons ────────────────────────────────────────
+
+@router.callback_query(F.data.startswith("faq_noop:"))
+async def faq_noop(callback: CallbackQuery) -> None:
+    await callback.answer()

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional
 
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.utils.keyboard import InlineKeyboardBuilder
 
 
 def talk_to_human_kb(t: Optional[Callable[[str], str]] = None) -> InlineKeyboardMarkup:
@@ -22,5 +23,29 @@ def admin_ticket_kb(conversation_id: int, ai_enabled: bool) -> InlineKeyboardMar
                 text=ai_label,
                 callback_data=f"toggle_ai:{conversation_id}",
             ),
+        ]
+    ])
+
+
+def faq_admin_list_kb(items: list[dict]) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    for item in items:
+        fid = item["id"]
+        builder.row(
+            InlineKeyboardButton(text=item["question"], callback_data=f"faq_noop:{fid}"),
+        )
+        builder.row(
+            InlineKeyboardButton(text="Edit", callback_data=f"faq_edit:{fid}"),
+            InlineKeyboardButton(text="Delete", callback_data=f"faq_del:{fid}"),
+        )
+    builder.row(InlineKeyboardButton(text="+ Add new", callback_data="faq_add"))
+    return builder.as_markup()
+
+
+def faq_confirm_delete_kb(faq_id: int) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(text="Yes", callback_data=f"faq_del_yes:{faq_id}"),
+            InlineKeyboardButton(text="No", callback_data="faq_del_no"),
         ]
     ])

--- a/main.py
+++ b/main.py
@@ -5,13 +5,14 @@ from typing import Any, Awaitable, Callable
 
 import aiosqlite
 from aiogram import Bot, Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.types import TelegramObject
 
 from bot.config import settings
 from bot.db.models import init_db
-from bot.handlers import admin, user
+from bot.handlers import admin, faq_admin, user
 from bot.middlewares.i18n import I18nMiddleware
 
 logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
@@ -43,7 +44,7 @@ async def main() -> None:
         token=settings.bot_token,
         default=DefaultBotProperties(parse_mode=ParseMode.HTML),
     )
-    dp = Dispatcher()
+    dp = Dispatcher(storage=MemoryStorage())
 
     db_mw = _DbMiddleware(settings.db_path)
     dp.message.middleware(db_mw)
@@ -52,6 +53,7 @@ async def main() -> None:
     dp.message.middleware(I18nMiddleware())
     dp.callback_query.middleware(I18nMiddleware())
 
+    dp.include_router(faq_admin.router)
     dp.include_router(user.router)
     dp.include_router(admin.router)
 


### PR DESCRIPTION
## Summary
- Add `faq_items` table to DB schema with position-based ordering
- Add full CRUD queries: `get_all_faq`, `get_faq_by_id`, `create_faq`, `update_faq`, `delete_faq`, `reorder_faq`
- New `bot/handlers/faq_admin.py` with FSM-based flows for add/edit/delete via `/faq` command in private chat (admin-only)
- Add `faq_admin_list_kb` and `faq_confirm_delete_kb` keyboard builders
- Register `faq_admin.router` in dispatcher with `MemoryStorage` for FSM support

## Test plan
- [ ] Run `/faq` in bot DM as admin — should show empty list with "Add new" button
- [ ] Add a FAQ item (text-only and photo+caption) — verify it appears in list
- [ ] Edit a FAQ item (skip question, change answer) — verify update
- [ ] Delete a FAQ item with confirmation — verify removal
- [ ] Run `/faq` as non-admin — should be ignored
- [ ] Run `/faq` in a group chat — should be ignored (private only)
- [ ] Verify existing bot functionality is unaffected

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)