### PR TITLE
fix: AI timeout, unbounded history, InaccessibleMessage guard

### DIFF
--- a/bot/ai/client.py
+++ b/bot/ai/client.py
@@ -30,6 +30,7 @@ async def _send_claude(history: list[dict], system_prompt: str) -> str:
         max_tokens=1024,
         system=system_prompt,
         messages=history,
+        timeout=30,
     )
     return response.content[0].text
 
@@ -39,5 +40,6 @@ async def _send_openai(history: list[dict], system_prompt: str) -> str:
     response = await _openai_client.chat.completions.create(
         model=settings.ai_model,
         messages=messages,
+        timeout=30,
     )
     return response.choices[0].message.content

--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -391,12 +391,12 @@ async def get_conversation_history(
 ) -> list[dict]:
     """Return messages as list of {role, content} dicts for AI client."""
     async with db.execute(
-        "SELECT role, text FROM messages WHERE conversation_id = ? ORDER BY id ASC",
+        "SELECT role, text FROM messages WHERE conversation_id = ? ORDER BY id DESC LIMIT 50",
         (conversation_id,),
     ) as cur:
         rows = await cur.fetchall()
     result = []
-    for role, text in rows:
+    for role, text in reversed(rows):
         # Map DB roles to AI roles
         if role == "ai":
             result.append({"role": "assistant", "content": text})

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -130,10 +130,11 @@ async def handle_close(
     closed_by = callback.from_user.id
     await queries.set_conversation_status(db, conv_id, "closed", closed_by=closed_by)
     await callback.answer(t("ticket_closed_admin"))
-    try:
-        await callback.message.edit_reply_markup(reply_markup=None)
-    except Exception:
-        pass
+    if isinstance(callback.message, Message):
+        try:
+            await callback.message.edit_reply_markup(reply_markup=None)
+        except Exception:
+            pass
 
 
 # ── Toggle AI callback ────────────────────────────────────────────────────────
@@ -154,12 +155,13 @@ async def handle_toggle_ai(
     await queries.set_ai_enabled(db, conv_id, new_state)
     label = t("ai_toggled_on") if new_state else t("ai_toggled_off")
     await callback.answer(label)
-    try:
-        await callback.message.edit_reply_markup(
-            reply_markup=admin_ticket_kb(conv_id, ai_enabled=new_state)
-        )
-    except Exception:
-        pass
+    if isinstance(callback.message, Message):
+        try:
+            await callback.message.edit_reply_markup(
+                reply_markup=admin_ticket_kb(conv_id, ai_enabled=new_state)
+            )
+        except Exception:
+            pass
 
 
 # ── Agent replies in admin topic → forward to user ───────────────────────────

--- a/bot/handlers/user.py
+++ b/bot/handlers/user.py
@@ -150,6 +150,9 @@ async def handle_faq_back(
     t: Callable[[str], str],
 ) -> None:
     faq_items = await queries.get_faq_items(db)
+    if not isinstance(callback.message, Message):
+        await callback.answer()
+        return
     if faq_items:
         await callback.message.edit_text(t("welcome"), reply_markup=faq_user_kb(faq_items))
     else:
@@ -172,6 +175,10 @@ async def handle_faq_item(
 
     item = await queries.get_faq_item(db, faq_id)
     if item is None:
+        await callback.answer()
+        return
+
+    if not isinstance(callback.message, Message):
         await callback.answer()
         return
 
@@ -297,10 +304,11 @@ async def handle_escalate(
     await queries.escalate_to_human(db, conv["id"])
 
     await callback.answer(t("escalated"))
-    try:
-        await callback.message.edit_reply_markup(reply_markup=None)
-    except Exception:
-        pass
+    if isinstance(callback.message, Message):
+        try:
+            await callback.message.edit_reply_markup(reply_markup=None)
+        except Exception:
+            pass
 
     tg_group_id = await queries.get_group_tg_id(db, user["group_id"])
     if tg_group_id is None:


### PR DESCRIPTION
## Summary
- Add `timeout=30` to both Claude and OpenAI API calls to prevent hanging handlers
- Limit conversation history sent to AI to the 50 most recent messages (fetched via `ORDER BY id DESC LIMIT 50`, then reversed) to avoid exceeding context windows and controlling costs
- Guard all `callback.message.edit_text`/`edit_reply_markup` calls with `isinstance(callback.message, Message)` to handle `InaccessibleMessage` gracefully (4 locations across user.py and admin.py)

Closes #20

## Test plan
- [ ] Verify AI replies still work with short conversations (< 50 messages)
- [ ] Verify long conversations only send last 50 messages to AI
- [ ] Simulate AI provider timeout (e.g., unreachable endpoint) — should fail after 30s, not hang
- [ ] Test inline button callbacks on old messages that may return `InaccessibleMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)